### PR TITLE
ggpolar enhancements.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Depends:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 Suggests:
     ncdf4,
     knitr,

--- a/R/ggpolar.R
+++ b/R/ggpolar.R
@@ -46,6 +46,10 @@
 #'   polar plots or at the mean longitude of a segment; use this parameter to
 #'   override the default setting.
 #' @param ax.labs.size size of latitude and longitude axis labels.
+#' @param clip Should drawing be clipped to the extent of the plot panel? A
+#'   setting of \code{"on"} (the default) means yes, and a setting of
+#'   \code{"off"} means no. For details, please see
+#'   \code{\link[ggplot2]{coord_cartesian}}.
 #' @param data.layer optional ggplot2 layer of data onto which the polar map
 #'   shall be plotted. Defaults to \code{NULL} which only plots the map.
 #' @import ggplot2 maptools rgeos
@@ -105,7 +109,7 @@ ggpolar <- function(pole = c("N", "S"),
                     plt.lat.axes = TRUE, plt.lat.labels = plt.lat.axes,
                     plt.lon.axes = TRUE, plt.lon.labels = plt.lon.axes,
                     rotate.long.labels = TRUE,
-                    lat.ax.labs.pos = NULL, ax.labs.size = 4,
+                    lat.ax.labs.pos = NULL, ax.labs.size = 4, clip = "on",
                     data.layer = NULL) {
 
   # force to repair invalid geometries
@@ -235,7 +239,7 @@ ggpolar <- function(pole = c("N", "S"),
 
     coord_map("ortho",
               orientation = c(ifelse(pole == "N", 90, -90), rotate.to, 0),
-              xlim = c(min.lon, max.lon)
+              xlim = c(min.lon, max.lon), clip = clip
               ) +
 
     # Remove axes and labels

--- a/R/ggpolar.R
+++ b/R/ggpolar.R
@@ -38,6 +38,9 @@
 #' @param plt.lon.axes logical; shall longitude axes be plotted?
 #' @param plt.lon.labels logical; shall longitude labels be plotted? Per default
 #'   set to the value of \code{plt.lon.axes}.
+#' @param rotate.long.labels logical; controls whether the longitude axis labels
+#'   are rotated according to their value and the setting of \code{rotate} (the
+#'   default) or not.
 #' @param lat.ax.labs.pos longitudinal positions of the latitude axis
 #'   labels. Per default, the labels are placed at 0 E (180 W) for north (south)
 #'   polar plots or at the mean longitude of a segment; use this parameter to
@@ -101,6 +104,7 @@ ggpolar <- function(pole = c("N", "S"),
                     rotate = FALSE, size.outer = 1,
                     plt.lat.axes = TRUE, plt.lat.labels = plt.lat.axes,
                     plt.lon.axes = TRUE, plt.lon.labels = plt.lon.axes,
+                    rotate.long.labels = TRUE,
                     lat.ax.labs.pos = NULL, ax.labs.size = 4,
                     data.layer = NULL) {
 
@@ -182,14 +186,22 @@ ggpolar <- function(pole = c("N", "S"),
   lat.lines <- expand.grid(long = min.lon : max.lon, lat = lat.ax.vals)
 
   # Define rotation angle for longitude labels
-  if (pole == "N") {
+  if (rotate.long.labels) {
 
-    long.ax.lab.rotation <- long.ax.vals - 180 - rotate.to
-    if (is.segment) long.ax.lab.rotation <- long.ax.lab.rotation + 180
+    if (pole == "N") {
+
+      long.ax.lab.rotation <- long.ax.vals - 180 - rotate.to
+      if (is.segment) long.ax.lab.rotation <- long.ax.lab.rotation + 180
+
+    } else {
+
+      long.ax.lab.rotation <- -long.ax.vals + rotate.to
+    }
 
   } else {
 
-    long.ax.lab.rotation <- -long.ax.vals + rotate.to
+    long.ax.lab.rotation <- 0
+
   }
 
   # Get map outline and crop

--- a/R/ggpolar.R
+++ b/R/ggpolar.R
@@ -14,6 +14,11 @@
 #'   "Black"); set to the same as \code{land.fill.colour} to hide them.
 #' @param n.lat.labels approximate number of latitude tickmarks.
 #' @param nearest.x.degrees round latitude tickmarks to how many degrees?
+#' @param f.long.label.ticks fraction of the plotted latitude axis range by
+#'   which the longitude ticksmarks extend behind the outer latitude axis,
+#'   i.e. the minimum (maximum) latitude for north (south) polar plots.
+#' @param f.long.label.pos fraction of the plotted latitude axis range by
+#'   which the longitude labels are offset from the outer latitude axis.
 #' @param rotate logical; if plotting a segment of < 360 degrees longitude,
 #'   rotate the plot so that north is up (or south is down) as seen from the
 #'   mean longitude of the segment.
@@ -82,8 +87,9 @@ ggpolar <- function(pole = c("N", "S"),
                     longitude.spacing = 60,
                     land.fill.colour = "Grey",
                     country.outline.colour = "Black",
-                    n.lat.labels = 4, nearest.x.degrees = 5, rotate = FALSE,
-                    size.outer = 1,
+                    n.lat.labels = 4, nearest.x.degrees = 5,
+                    f.long.label.ticks = 20, f.long.label.pos = 7,
+                    rotate = FALSE, size.outer = 1,
                     plt.lat.axes = TRUE, plt.lat.labels = plt.lat.axes,
                     plt.lon.axes = TRUE, plt.lon.labels = plt.lon.axes,
                     lat.ax.labs.pos = NULL, ax.labs.size = 4,
@@ -123,8 +129,8 @@ ggpolar <- function(pole = c("N", "S"),
 
     outer.lat.ax.val <- min.lat
     inner.lat.ax.val <- ifelse(max.lat == 90, NA, max.lat)
-    long.lab.pos.1 <- outer.lat.ax.val - (lat.range / 20)
-    long.lab.pos.2 <- outer.lat.ax.val - (lat.range / 7)
+    long.lab.pos.1 <- outer.lat.ax.val - (lat.range / f.long.label.ticks)
+    long.lab.pos.2 <- outer.lat.ax.val - (lat.range / f.long.label.pos)
 
     long.line.strt <- max.lat
     long.line.end <- long.lab.pos.1
@@ -135,8 +141,8 @@ ggpolar <- function(pole = c("N", "S"),
 
     outer.lat.ax.val <- max.lat
     inner.lat.ax.val <- ifelse(min.lat == -90, NA, min.lat)
-    long.lab.pos.1 <- outer.lat.ax.val + (lat.range / 20)
-    long.lab.pos.2 <- outer.lat.ax.val + (lat.range / 7)
+    long.lab.pos.1 <- outer.lat.ax.val + (lat.range / f.long.label.ticks)
+    long.lab.pos.2 <- outer.lat.ax.val + (lat.range / f.long.label.pos)
 
     long.line.strt <- long.lab.pos.1
     long.line.end <- min.lat

--- a/R/ggpolar.R
+++ b/R/ggpolar.R
@@ -19,6 +19,14 @@
 #'   i.e. the minimum (maximum) latitude for north (south) polar plots.
 #' @param f.long.label.pos fraction of the plotted latitude axis range by
 #'   which the longitude labels are offset from the outer latitude axis.
+#' @param lat.ax.vals manually set the latitude axis values where to plot
+#'   latitude labels and lines. This overrides the automatic setting by
+#'   \code{n.lat.labels} and \code{x.nearest.degress}, while the default
+#'   \code{NULL} means to use the automatic setting.
+#' @param long.ax.vals manually set the longitude axis values where to plot
+#'   longitude labels and lines. This overrides the automatic setting by
+#'   \code{longitude.spacing}, while the default \code{NULL} means to use the
+#'   automatic setting.
 #' @param rotate logical; if plotting a segment of < 360 degrees longitude,
 #'   rotate the plot so that north is up (or south is down) as seen from the
 #'   mean longitude of the segment.
@@ -89,6 +97,7 @@ ggpolar <- function(pole = c("N", "S"),
                     country.outline.colour = "Black",
                     n.lat.labels = 4, nearest.x.degrees = 5,
                     f.long.label.ticks = 20, f.long.label.pos = 7,
+                    lat.ax.vals = NULL, long.ax.vals = NULL,
                     rotate = FALSE, size.outer = 1,
                     plt.lat.axes = TRUE, plt.lat.labels = plt.lat.axes,
                     plt.lon.axes = TRUE, plt.lon.labels = plt.lon.axes,
@@ -125,7 +134,9 @@ ggpolar <- function(pole = c("N", "S"),
   # Hemisphere specific values
   if (pole == "N") {
 
-    lat.ax.vals <- seq(min.lat + d.lat.ax.vals, max.lat, by = d.lat.ax.vals)
+    if (!length(lat.ax.vals)) {
+      lat.ax.vals <- seq(min.lat + d.lat.ax.vals, max.lat, by = d.lat.ax.vals)
+    }
 
     outer.lat.ax.val <- min.lat
     inner.lat.ax.val <- ifelse(max.lat == 90, NA, max.lat)
@@ -137,7 +148,9 @@ ggpolar <- function(pole = c("N", "S"),
 
   } else if (pole == "S") {
 
-    lat.ax.vals <- seq(max.lat - d.lat.ax.vals, min.lat, by = -d.lat.ax.vals)
+    if (!length(lat.ax.vals)) {
+      lat.ax.vals <- seq(max.lat - d.lat.ax.vals, min.lat, by = -d.lat.ax.vals)
+    }
 
     outer.lat.ax.val <- max.lat
     inner.lat.ax.val <- ifelse(min.lat == -90, NA, min.lat)
@@ -153,7 +166,9 @@ ggpolar <- function(pole = c("N", "S"),
                         "°", ifelse(lat.ax.vals < 0, " S", " N"))
 
   # Define the x axes required
-  long.ax.vals <- seq(min.lon, max.lon, by = longitude.spacing)
+  if (!length(long.ax.vals)) {
+    long.ax.vals <- seq(min.lon, max.lon, by = longitude.spacing)
+  }
 
   if (!is.segment) {
     long.ax.vals <- long.ax.vals[long.ax.vals != -180]

--- a/R/ggpolar.R
+++ b/R/ggpolar.R
@@ -17,8 +17,8 @@
 #' @param rotate logical; if plotting a segment of < 360 degrees longitude,
 #'   rotate the plot so that north is up (or south is down) as seen from the
 #'   mean longitude of the segment.
-#' @param size.outer size of the outer longitude circle and, if plotting a
-#'   segment, of the outer latitude lines.
+#' @param size.outer size of the outer (and potential inner) longitude circle
+#'   and, if plotting a segment, of the outer latitude lines.
 #' @param plt.lat.axes logical; shall latitude axes be plotted?
 #' @param plt.lat.labels logical; shall latitude labels be plotted? Per default
 #'   set to the value of \code{plt.lat.axes}.
@@ -122,6 +122,7 @@ ggpolar <- function(pole = c("N", "S"),
     lat.ax.vals <- seq(min.lat + d.lat.ax.vals, max.lat, by = d.lat.ax.vals)
 
     outer.lat.ax.val <- min.lat
+    inner.lat.ax.val <- ifelse(max.lat == 90, NA, max.lat)
     long.lab.pos.1 <- outer.lat.ax.val - (lat.range / 20)
     long.lab.pos.2 <- outer.lat.ax.val - (lat.range / 7)
 
@@ -133,6 +134,7 @@ ggpolar <- function(pole = c("N", "S"),
     lat.ax.vals <- seq(max.lat - d.lat.ax.vals, min.lat, by = -d.lat.ax.vals)
 
     outer.lat.ax.val <- max.lat
+    inner.lat.ax.val <- ifelse(min.lat == -90, NA, min.lat)
     long.lab.pos.1 <- outer.lat.ax.val + (lat.range / 20)
     long.lab.pos.2 <- outer.lat.ax.val + (lat.range / 7)
 
@@ -209,10 +211,16 @@ ggpolar <- function(pole = c("N", "S"),
 
     # Outer latitude axis
     geom_line(aes(y = outer.lat.ax.val, x = min.lon : max.lon),
-              size = size.outer, colour = "black") +
+              size = size.outer, colour = "black")
+
+    # Inner latitude axis
+    if (!is.na(inner.lat.ax.val)) {
+      p <- p + geom_line(aes(y = inner.lat.ax.val, x = min.lon : max.lon),
+                         size = size.outer, colour = "black")
+    }
 
     # Change theme to remove panel backgound
-    theme(panel.background = element_blank())
+    p <- p + theme(panel.background = element_blank())
 
   # Add axes and labels
 

--- a/man/ecustools.Rd
+++ b/man/ecustools.Rd
@@ -4,6 +4,3 @@
 \name{ecustools}
 \alias{ecustools}
 \title{ecustools.}
-\description{
-ecustools.
-}

--- a/man/ggpolar.Rd
+++ b/man/ggpolar.Rd
@@ -19,14 +19,20 @@ ggpolar(
   country.outline.colour = "Black",
   n.lat.labels = 4,
   nearest.x.degrees = 5,
+  f.long.label.ticks = 20,
+  f.long.label.pos = 7,
+  lat.ax.vals = NULL,
+  long.ax.vals = NULL,
   rotate = FALSE,
   size.outer = 1,
   plt.lat.axes = TRUE,
   plt.lat.labels = plt.lat.axes,
   plt.lon.axes = TRUE,
   plt.lon.labels = plt.lon.axes,
+  rotate.long.labels = TRUE,
   lat.ax.labs.pos = NULL,
   ax.labs.size = 4,
+  clip = "on",
   data.layer = NULL
 )
 }
@@ -52,12 +58,29 @@ ggpolar(
 
 \item{nearest.x.degrees}{round latitude tickmarks to how many degrees?}
 
+\item{f.long.label.ticks}{fraction of the plotted latitude axis range by
+which the longitude ticksmarks extend behind the outer latitude axis,
+i.e. the minimum (maximum) latitude for north (south) polar plots.}
+
+\item{f.long.label.pos}{fraction of the plotted latitude axis range by
+which the longitude labels are offset from the outer latitude axis.}
+
+\item{lat.ax.vals}{manually set the latitude axis values where to plot
+latitude labels and lines. This overrides the automatic setting by
+\code{n.lat.labels} and \code{x.nearest.degress}, while the default
+\code{NULL} means to use the automatic setting.}
+
+\item{long.ax.vals}{manually set the longitude axis values where to plot
+longitude labels and lines. This overrides the automatic setting by
+\code{longitude.spacing}, while the default \code{NULL} means to use the
+automatic setting.}
+
 \item{rotate}{logical; if plotting a segment of < 360 degrees longitude,
 rotate the plot so that north is up (or south is down) as seen from the
 mean longitude of the segment.}
 
-\item{size.outer}{size of the outer longitude circle and, if plotting a
-segment, of the outer latitude lines.}
+\item{size.outer}{size of the outer (and potential inner) longitude circle
+and, if plotting a segment, of the outer latitude lines.}
 
 \item{plt.lat.axes}{logical; shall latitude axes be plotted?}
 
@@ -69,12 +92,21 @@ set to the value of \code{plt.lat.axes}.}
 \item{plt.lon.labels}{logical; shall longitude labels be plotted? Per default
 set to the value of \code{plt.lon.axes}.}
 
+\item{rotate.long.labels}{logical; controls whether the longitude axis labels
+are rotated according to their value and the setting of \code{rotate} (the
+default) or not.}
+
 \item{lat.ax.labs.pos}{longitudinal positions of the latitude axis
 labels. Per default, the labels are placed at 0 E (180 W) for north (south)
 polar plots or at the mean longitude of a segment; use this parameter to
 override the default setting.}
 
 \item{ax.labs.size}{size of latitude and longitude axis labels.}
+
+\item{clip}{Should drawing be clipped to the extent of the plot panel? A
+setting of \code{"on"} (the default) means yes, and a setting of
+\code{"off"} means no. For details, please see
+\code{\link[ggplot2]{coord_cartesian}}.}
 
 \item{data.layer}{optional ggplot2 layer of data onto which the polar map
 shall be plotted. Defaults to \code{NULL} which only plots the map.}


### PR DESCRIPTION
This PR introduces enhancements of the `ggpolar` function; specifically:
* an inner longitude circle is plotted in addition to the outer one, if the plot region does not extend to +90 or -90 degree latitude. This makes a visible border of the plotting region when the land mask does not create a boundary by itself and is specifically useful for the plotting of segments;
* you can now control the offset of the longitude axis labels and tickmarks relative to the outer latitude line;
* you can specify custom longitude and latitude values where to position axis labels and lines. This overrides the automatic setting of these values;
* the automatic rotation of the longitude axis labels has been turned into a settable function parameter, which implements your request, @andrewdolman, in #4;
* a new function parameter `clip` is introduced by which one can switch off the automatic clipping of text labels which extend beyond the plot panel. This switch is passed on to the `ggplot2::coord_map` function which controls the clipping. See the `ggplot2` documentation for details.
* package documentation is updated to reflect the above updates.

All new function parameters are introduced such that the default settings yield the plotting behaviour as before.