### PR TITLE
Implement pkg soft deprecation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ecustools
 Title: A miscellaneous collection of R functions for working with time-series
     and paleo data.
-Version: 0.1
+Version: 0.1.9999
 Author:
   Andrew Dolman [aut, cre],
   Thomas Laepple [aut],
@@ -38,7 +38,8 @@ Imports:
     rgeos,
     mapproj,
     geosphere,
-    Bchron
+    Bchron,
+    rlang
 Remotes: 
     earthsystemdiagnostics/orbitalforcing,
     earthsystemdiagnostics/pfields

--- a/R/BarometricFormula.R
+++ b/R/BarometricFormula.R
@@ -14,6 +14,7 @@
 ##' @export
 BarometricFormula <- function(T, h, p0 = 1013) {
 
+  function_deprecated("geostools")
     kR <- 8.314
     kg <- 9.807
     kM <- 0.02896
@@ -25,4 +26,3 @@ BarometricFormula <- function(T, h, p0 = 1013) {
     return(p0 * exp(-h / hs))
 
 }
-

--- a/R/CalibrateAge.R
+++ b/R/CalibrateAge.R
@@ -40,7 +40,7 @@ CalibrateAge <- function(df, age.14C = "age.14C",
                          age.14C.se = "age.14C.se",
                          curve = "intcal20", 
                          return.type = "df", offset = NULL){
-
+  function_deprecated("prxytools")
   return.type <- match.arg(return.type, choices = c("df", "lst"))
   curve <- match.arg(curve, choices = c("intcal13", "shcal13", "marine13",
                                         "intcal20", "marine20", "shcal20",

--- a/R/CircleCoordinates.R
+++ b/R/CircleCoordinates.R
@@ -24,7 +24,7 @@
 CircleCoordinates <- function(lat0, lon0, radius.circle,
                               radius.sphere = 6357, n = 100,
                               return.pi.interval = FALSE) {
-
+  function_deprecated("geostools")
   # Put input longitude in [-pi, pi]
   if (lon0 >= 180) lon0 <- lon0 - 360
 

--- a/R/DistAB.R
+++ b/R/DistAB.R
@@ -17,9 +17,7 @@
 #' DistAB(0,-75,c(0,1,2,3),c(-76,-75,-74,-73))
 #' @export
 DistAB <- function(lon,lat,lons,lats) {
-  warning(paste("'DistAB()' is deprecated and will be removed soon.",
-                "Use 'GetDistance()' or 'geosphere::distGeo()' instead."),
-          call. = FALSE)
+  function_deprecated("geostools", new.name = "GetDistance")
   a=6.378e06
   good <- is.finite(lons) & is.finite(lats)
   lons <- lons[good]

--- a/R/GetDistance.R
+++ b/R/GetDistance.R
@@ -52,7 +52,7 @@
 #' @export
 GetDistance <- function(lat0, lon0, lat, lon,
                         get.nearest = FALSE, verbose = FALSE) {
-
+  function_deprecated("geostools")
   # Error checking
 
   if (length(lat0) != length(lon0))

--- a/R/GetNetCDFAtCoords.R
+++ b/R/GetNetCDFAtCoords.R
@@ -21,7 +21,7 @@
 #' }
 GetNetCDFAtCoords <- function(filename, req.coords, req.var, time.var = "time",
                               lon.var = "longitude", lat.var = "latitude"){
-  
+  function_deprecated("ncdftools")
   if (!requireNamespace("ncdf4", quietly = TRUE)) {
     stop("package 'ncdf4' is needed for this function to work. Please install it.
          Linux users may have to install the 3rd party libraries libnetcdf-dev

--- a/R/ImpulseResponse.BergerHeath.R
+++ b/R/ImpulseResponse.BergerHeath.R
@@ -6,6 +6,7 @@
 #' @author Thomas Laepple
 #' @export
 ImpulseResponse.BergerHeath <- function(z, d, z0 = 0) {
+  function_deprecated("prxytools")
   x <- z0 + d - z
   epsilon <- x/d
   result <- 1/d * exp(-epsilon)

--- a/R/PlotPairwiseCorrelations.R
+++ b/R/PlotPairwiseCorrelations.R
@@ -39,6 +39,7 @@ PlotPairwiseCorrelations <- function(M,
                                      axis.label = NULL,
                                      return.corr.tibble = FALSE,
                                      plotit = TRUE){
+  function_deprecated("grfxtools")
   if (is.null(colnames(M))) colnames(M) <- 1:ncol(M)
   c.m <- cor(M)
   c.m[lower.tri(c.m, diag = TRUE)] <- NA

--- a/R/Polyplot.R
+++ b/R/Polyplot.R
@@ -19,7 +19,7 @@
 ##' lines(x, lwd = 2)
 ##' @export
 Polyplot <- function(x, y1, y2, col = "black", alpha = 0.2, ...) {
-
+  function_deprecated("grfxtools")
     inp <- list(x, y1, y2)
     if (var(sapply(inp, length)) != 0)
         stop("All input vectors must be of the same length.")

--- a/R/RWeights.R
+++ b/R/RWeights.R
@@ -8,6 +8,7 @@
 #' hist(RWeights(100000, weights), breaks = 501)
 #' @export
 RWeights <- function(n = 1000, weights) {
+  function_deprecated("stattools")
   base::sample.int(length(weights),
     n,
     prob = weights,

--- a/R/ReadCMIP5Ensemble.R
+++ b/R/ReadCMIP5Ensemble.R
@@ -28,6 +28,7 @@ ReadCMIP5Ensemble <- function(path = "", bFullEnsemble = TRUE,
                               DATADIR = path, PREFIX = "tas_Amon_",
                               MIDDLE = "_historical_", SUFFIX = ".nc",
                               varname = "tas") {
+  stop("Package 'ecustools' and this function are deprecated!")
   b.meta <- read.table(METAFILE, header = FALSE)
   meta <- list(names = vector(), modelName = vector(), ensMember = vector())
   cdat <- list()

--- a/R/ReadFraile.R
+++ b/R/ReadFraile.R
@@ -18,7 +18,7 @@
 #'                   varname = "var.name")
 #' }
 ReadFraile <- function(FILENAME, varname){
-
+  stop("Package 'ecustools' and this function are deprecated!")
   if (!requireNamespace("ncdf4", quietly = TRUE)) {
     stop("package 'ncdf4' is needed for this function to work. Please install it.
          Linux users may have to install the 3rd party libraries libnetcdf-dev

--- a/R/d18O-calibration.R
+++ b/R/d18O-calibration.R
@@ -24,6 +24,7 @@
 #' @examples
 #' d18OwFromSalinity(30)
 d18OwFromSalinity <- function(Salinity){
+  function_deprecated("prxytools")
   -19.264 + 0.558 * Salinity
 }
 
@@ -56,6 +57,7 @@ d18OwFromSalinity <- function(Salinity){
 #' @examples
 #'d18OcFromd18OwTemp(d18Ow = 0.6, 1:26)
 d18OcFromd18OwTemp <- function(d18Ow, Temp){
+  function_deprecated("prxytools")
   (d18Ow - 0.27) + (4.38 - (4.38^2 - 4 * 0.1 * (16.9 - Temp))^0.5) / (2 * 0.1)
 }
 
@@ -72,6 +74,7 @@ d18OcFromd18OwTemp <- function(d18Ow, Temp){
 #' @examples
 #' CalcifTemp(d18OcFromd18OwTemp(d18Ow = 0.6, 1:26), 0.6)
 CalcifTemp <- function(d18Oc, d18Ow){
+  function_deprecated("prxytools")
   16.9 - 4.38 * (d18Oc - (d18Ow - 0.27)) + 0.1 *
     (d18Oc - (d18Ow - 0.27))^2
 }

--- a/R/deg2rad.R
+++ b/R/deg2rad.R
@@ -11,6 +11,7 @@
 #' deg2rad(deg2rad(-75), inverse = TRUE)
 #' @export
 deg2rad <- function(x, inverse = FALSE) {
+  function_deprecated("geostools")
   f <- ifelse(inverse, 180 / pi, pi / 180)
   f * x
 }

--- a/R/distribution-seasonal-temperatures.R
+++ b/R/distribution-seasonal-temperatures.R
@@ -39,7 +39,7 @@ NULL
 #' @rdname SeasonalCycle
 #' @export
 dSeas <- function(x=NULL, mean.t, amp.t, sd.t, return = c("density", "FUN"), res = 0.01) {
-
+  function_deprecated("stattools")
   rng <- max(c(amp.t, sd.t * 5))
   lnth <- (2 * rng) / res
 
@@ -78,6 +78,7 @@ dSeas <- function(x=NULL, mean.t, amp.t, sd.t, return = c("density", "FUN"), res
 #' @param n number of samples
 #' @export
 rSeas <- function(n, mean.t, amp.t, sd.t){
+  function_deprecated("stattools")
   x <- runif(n, 0, 2*pi)
   y <- mean.t + sin(x) * amp.t/2
   z <- y + rnorm(n, 0, sd.t)
@@ -91,6 +92,7 @@ rSeas <- function(n, mean.t, amp.t, sd.t){
 #' @param amp.t amplitude of sine wave
 #' @export
 dSin <- function(x, mean.t, amp.t) {
+  function_deprecated("stattools")
   d <- rep(0, length(x))
 
   # Do not evaluate where known to be NaN

--- a/R/ecustools-package.r
+++ b/R/ecustools-package.r
@@ -1,4 +1,4 @@
-#' ecustools.
+#' ecustools is deprecated!
 #'
 #' @name ecustools
 #' @docType package

--- a/R/ggplot2-helpers.R
+++ b/R/ggplot2-helpers.R
@@ -11,6 +11,7 @@
 #' @export
 #' @importFrom scales trans_new log_breaks
 reverselog_trans <- function(base = exp(1)) {
+  function_deprecated("grfxtools")
   trans <- function(x) -log(x, base)
   inv <- function(x) base^(-x)
   scales::trans_new(paste0("reverselog-", format(base)), trans, inv,
@@ -47,6 +48,7 @@ reverselog_trans <- function(base = exp(1)) {
 #'                                nrow = 2, ncol = 2)
 #' gg
 facet_wrap_paginate_auto <- function(ggplot.obj, facets, nrow, ncol) {
+  function_deprecated("grfxtools")
   built.plot <- ggplot_build(ggplot.obj)
 
   # Make robust to changes in built ggplot object stucture in dev vs. CRAN version

--- a/R/ggpolar.R
+++ b/R/ggpolar.R
@@ -111,7 +111,7 @@ ggpolar <- function(pole = c("N", "S"),
                     rotate.long.labels = TRUE,
                     lat.ax.labs.pos = NULL, ax.labs.size = 4, clip = "on",
                     data.layer = NULL) {
-
+  function_deprecated("grfxtools")
   # force to repair invalid geometries
   rgeos::set_RGEOS_CheckValidity(2L)
 

--- a/R/interp.barycentric.R
+++ b/R/interp.barycentric.R
@@ -36,6 +36,7 @@
 #'
 #' hist(out$v - out$v_true)
 InterpBarycentric <- function(X, f, Xi) {
+  function_deprecated("geostools")
   X <- as.matrix(X)
   Xi <- as.matrix(Xi)
   dn <- geometry::delaunayn(X)

--- a/R/rmsd.R
+++ b/R/rmsd.R
@@ -15,7 +15,7 @@
 #' rmsd(v1, v2)
 #' @export
 rmsd <- function(v1, v2, na.rm = FALSE) {
-
+  function_deprecated("stattools")
   if (length(v1) != length(v2)) {
     stop("Arguments must have the same length.")
   }

--- a/R/statistical-functions.R
+++ b/R/statistical-functions.R
@@ -14,6 +14,7 @@
 #' 
 #' PopSD(1:10)
 PopSD <- function(x){
+  function_deprecated("stattools")
   n <- length(x)
   adj <- sqrt((n-1) / n)
   adj * sd(x)
@@ -46,6 +47,7 @@ PopSD <- function(x){
 #' @rdname SDofSD
 #' @export
 SDofSD <- function(s, n) {
+  function_deprecated("stattools")
   if (any(n < 2, na.rm = TRUE))
     warning("n must be greater than or equal to 2")
   if (any(s < 0, na.rm = TRUE))
@@ -106,6 +108,7 @@ SDofSD <- function(s, n) {
 #'  }
 #' }
 SDofNumDist <- function(x, d){
+  function_deprecated("stattools")
   d <- d / sum(d)
   sqrt(sum(d*x^2) - sum(d*x)^2)
 }
@@ -126,7 +129,7 @@ SDofNumDist <- function(x, d){
 #' df$p <- dnorm(df$x, 5, 2)
 #' SummariseEmpiricalPDF(df$x, df$p)
 SummariseEmpiricalPDF <- function(x, p){
-
+  function_deprecated("stattools")
   # Ensure x and p are sorted
   p <- p[order(x)]
   x <- sort(x)
@@ -188,7 +191,7 @@ SummariseEmpiricalPDF <- function(x, p){
 #'   facet_wrap(~n)
 #'   }
 ExpectedRange <- function(sd, n) {
-
+  function_deprecated("stattools")
   f <- function(x, n) n * x * pnorm(x)^(n - 1) * dnorm(x)
 
   exp.range <- 2 * sd * integrate(f, -Inf, Inf, n = n)$value

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,30 @@
 
-# .onLoad <- function(libname, pkgname) {
-#
-# }
+.onAttach <- function(libname, pkgname) {
 
+  msg <- paste("Package 'ecustools' is deprecated!",
+               "Please start to use its descendants:\n\n",
+               "https://github.com/EarthSystemDiagnostics/grfxtools\n",
+               "https://github.com/EarthSystemDiagnostics/geostools\n",
+               "https://github.com/EarthSystemDiagnostics/stattools\n",
+               "https://github.com/EarthSystemDiagnostics/prxytools\n",
+               "https://github.com/EarthSystemDiagnostics/ncdftools\n",
+               "https://github.com/EarthSystemDiagnostics/pfields\n",
+               "https://github.com/EarthSystemDiagnostics/orbitalforcing\n")
+  warning(msg, call. = FALSE)
+
+}
+
+function_deprecated <- function(successor, new.name = NULL) {
+
+  old.name <- rlang::call_frame(n = 2)$fn_name
+  if (is.null(new.name)) new.name <- old.name
+
+  msg <- paste0(
+    sprintf("You called function '%s' from package 'ecustools'.\n", old.name),
+    "Package 'ecustools' is deprecated!\n\n",
+    sprintf("Please use %s::%s() from package '%s'.\n",
+            successor, new.name, successor))
+
+  warning(msg, call. = FALSE)
+
+}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,32 @@
 ecustools
 ================
 
-A miscellaneous collection of R functions used in the ECUS group for working with time-series and paleo data.
+**OBS!**
 
-Many of these functions have been ported from the 'paleoLibrary' collection of R scripts.
+This package is **deprecated** and this repository will be made read-only and
+archived in due time!
 
-This R package is not on CRAN, to install:
+Please migrate to the successor packages listed below!
 
-``` r
-# install.packages("devtools")
-devtools::install_github("EarthSystemDiagnostics/ecustools")
-```
+Originally, **ecustools** consisted of a miscellaneous collection of R functions
+used in the ECUS group for working with time-series and paleo data, with many of
+the functions having been ported from the 'paleoLibrary' collection of R
+scripts.
+
+Most of the package's original content was now migrated to a set of smaller,
+more structured and theme-oriented packages, superseding **ecustools**:
+
+* [pfields](https://github.com/EarthSystemDiagnostics/pfields): handling and
+  analysis of gridded field data;
+* [grfxtools](https://github.com/EarthSystemDiagnostics/grfxtools): assistance
+  for various plotting tasks;
+* [geostools](https://github.com/EarthSystemDiagnostics/geostools): assistance
+  for handling geoscientific problems;
+* [stattools](https://github.com/EarthSystemDiagnostics/stattools): tools for
+  statistical analyses;
+* [prxytools](https://github.com/EarthSystemDiagnostics/prxytools): assistance
+  for proxy analyses;
+* [ncdftools](https://github.com/EarthSystemDiagnostics/ncdftools): handling of
+  NetCDF files;
+* [orbitalforcing](https://github.com/EarthSystemDiagnostics/orbitalforcing):
+  calculation of climate orbital forcing.


### PR DESCRIPTION
Package ecustools is deprecated and superseded by its successor packages:
* [pfields](https://github.com/EarthSystemDiagnostics/pfields);
* [grfxtools](https://github.com/EarthSystemDiagnostics/grfxtools);
* [geostools](https://github.com/EarthSystemDiagnostics/geostools);
* [stattools](https://github.com/EarthSystemDiagnostics/stattools);
* [prxytools](https://github.com/EarthSystemDiagnostics/prxytools);
* [ncdftools](https://github.com/EarthSystemDiagnostics/ncdftools);
* [orbitalforcing](https://github.com/EarthSystemDiagnostics/orbitalforcing).

This PR implements soft deprecation of the package so that users will be urged to migrate to the successor packages. Soft deprecation includes issuing of warning messages when the package is attached and when using a function from the package. In the latter case, the warning message includes the information which successor package now hosts the respective function.