### PR TITLE
Implement pkg hard deprecation

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -25,6 +25,6 @@ function_deprecated <- function(successor, new.name = NULL) {
     sprintf("Please use %s::%s() from package '%s'.\n",
             successor, new.name, successor))
 
-  warning(msg, call. = FALSE)
+  stop(msg, call. = FALSE)
 
 }


### PR DESCRIPTION
This is the follow-up on #10 and implements hard deprecation of **ecustools** and by this finalizes the deprecation procedure. The hard deprecation leads to now issuing an error message whenever a function from ecustools is called (still including the information which successor package now hosts the respective function).